### PR TITLE
"차량 충돌로 인한 게임오버 시 씬전환이 되지 않는 오류 수정"

### DIFF
--- a/Assets/Scripts/CarObj.cs
+++ b/Assets/Scripts/CarObj.cs
@@ -24,8 +24,7 @@ public class CarObj : MonoBehaviour
         crash();
         if(other.gameObject.CompareTag("Player")){
                 Debug.Log("플레이어와 충돌 감지됨! Die() 실행");
-                GameManager.inst.Stop();
-            SceneManager.LoadScene("GameOverScene");
+            GameManager.inst.GameOver();
         }
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 
-public class GameManager : MonoBehaviour {
+public class GameManager : MonoBehaviour
+{
     public static GameManager inst;         // �ܺο��� GameManager �Լ��� �����ϰ� ���� �� GameManager.inst.function() �������� �����ϸ� �˴ϴ�.
     public PoolManager pool;                // �ܺο��� PoolManager �Լ��� �����ϰ� ���� �� GameManager.inst.pool.function() �������� �����ϸ� �˴ϴ�.
     public Player player;                   // �ܺο��� Player�� �����ϰ� ���� �� GameManager.inst.player.function() �������� �����ϸ� �˴ϴ�.
@@ -19,19 +20,28 @@ public class GameManager : MonoBehaviour {
         inst = this;
     }
 
-    void Start(){
+    void Start()
+    {
     }
 
-    void Update(){
+    void Update()
+    {
     }
 
     public void Stop()      // ���� ����� 0������� ����. �� ���� ���ߴ� �Լ��Դϴ�.
     {
         Time.timeScale = 0;
     }
-    
+
     public void Resume()    // ���� ����� 1������� ����. �� ���� �簳�ϴ� �Լ��Դϴ�.
     {
         Time.timeScale = 1;
     }
+
+    public void GameOver()
+    {
+        Time.timeScale = 1; // 혹시 멈춰있을 수도 있으니 복원
+        SceneManager.LoadScene("GameOverScene");
+    }
+
 }


### PR DESCRIPTION
타임스케일을 0으로 만들고 씬을 전환화면 코루틴, 애니매이션, 델타타임 등 시간 기반 기능들이 정지되어서
그 다음씬부터 씬전환 애니메이션이 동작하지 못하는 듯 합니다!

변경사항
GameManager.cs
    public void GameOver()
    {
        Time.timeScale = 1; // 혹시 멈춰있을 수도 있으니 복원
        SceneManager.LoadScene("GameOverScene");
    }
추가
-------------------------------------------------
CarObj.cs -> OnCollisionEnter2D()
GameManager.inst.stop()
SceneManager.LoadScene("GameOverScene");
-> 이 부분 변경
GameManager.inst.GameOver();
-------------------------------------------------