### PR TITLE
추가사항 많아서 설명란에 적어두겠습니다@@

### DIFF
--- a/Assets/Editor/Scenes/MainMenuScene.unity
+++ b/Assets/Editor/Scenes/MainMenuScene.unity
@@ -1305,7 +1305,8 @@ MonoBehaviour:
   data:
     gold: 500
     money: 10000
-    turn: 0
+    turn: 5
+    maxTurnsPerRound: 5
     currentRound: 0
     paidStageIndex: 0
     ownedItems: []

--- a/Assets/Scripts/GameDataManager.cs
+++ b/Assets/Scripts/GameDataManager.cs
@@ -63,7 +63,7 @@ public class GameDataManager : MonoBehaviour
             Debug.Log("🎉 최초 실행 - 기본값 세팅");
             data.gold = 100;
             data.money = 10000;
-            data.turn = 0;
+            data.turn = 5;
             data.paidStageIndex = 0;
             data.currentRound = 1;
             data.ownedItems = new List<SerializableItem>();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -103,7 +103,7 @@ public class GameManager : MonoBehaviour
             GameDataManager.Instance.Save();
         }
 
-        LoadSceneManager.Instance.ChangeScene("Shop 2"); // ← 여기까지 도달하는 건 안전한 경우만
+        LoadSceneManager.Instance.ChangeScene("Shop 2"); // ← 납부할 돈이 충분하면 Shop 2로 이동.
     }
 
     public void GameOver()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -70,13 +70,13 @@ public class GameManager : MonoBehaviour
     public void RoundOver()
     {
         Time.timeScale = 1; // 혹시 멈춰있을 수도 있으니 복원
-        SceneManager.LoadScene("Shop 2");
+        LoadSceneManager.Instance.ChangeScene("Shop 2");
     }
 
     public void GameOver()
     {
         Time.timeScale = 1; // 혹시 멈춰있을 수도 있으니 복원
-        SceneManager.LoadScene("GameOverScene");
+        LoadSceneManager.Instance.ChangeScene("GameOverScene");
     }
 
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -69,8 +69,41 @@ public class GameManager : MonoBehaviour
 
     public void RoundOver()
     {
-        Time.timeScale = 1; // 혹시 멈춰있을 수도 있으니 복원
-        LoadSceneManager.Instance.ChangeScene("Shop 2");
+        Time.timeScale = 1;
+
+        if (GameDataManager.Instance != null)
+        {
+            GameDataManager.Instance.data.turn--;
+
+            if (GameDataManager.Instance.data.turn < 0)
+                GameDataManager.Instance.data.turn = 0;
+
+            Debug.Log($"턴 감소! 남은 턴: {GameDataManager.Instance.data.turn}");
+
+            // 턴 0일 경우 납부 시도 → 실패 시 조기 종료
+            if (GameDataManager.Instance.data.turn == 0)
+            {
+                Debug.Log("💰 턴 종료 - 납부 시도 중");
+
+                bool success = GameDataManager.Instance.TryPay();
+
+                if (!success)
+                {
+                    Debug.Log("납부 실패 - 게임 오버로 전환");
+                    GameOver(); // 🚨 게임 오버 처리
+                    return;     // ⛔ 이후 씬 전환 방지
+                }
+                else
+                {
+                    Debug.Log("납부 성공 - 다음 라운드로 이동");
+                    // (선택) GameDataManager.Instance.data.turn = 5;
+                }
+            }
+
+            GameDataManager.Instance.Save();
+        }
+
+        LoadSceneManager.Instance.ChangeScene("Shop 2"); // ← 여기까지 도달하는 건 안전한 경우만
     }
 
     public void GameOver()

--- a/Assets/Scripts/SaveData.cs
+++ b/Assets/Scripts/SaveData.cs
@@ -30,6 +30,9 @@ public class GameData
     public int money;
     public int turn;
 
+    // 해당 납부 단계에서 최대 플레이 가능한 라운드 수
+    public int maxTurnsPerRound = 5;
+
     //납부 관련
     public int currentRound;
     public int paidStageIndex;

--- a/Assets/Scripts/Sh/PlayerCollision.cs
+++ b/Assets/Scripts/Sh/PlayerCollision.cs
@@ -8,50 +8,65 @@ public class PlayerCollisionWarning : MonoBehaviour
     private float cooldown = 1f;        // 쿨타임 1초
     private float lastWarningTime = -10f;  // 마지막 경고 시간 초기값 (충돌 직후에도 바로 메시지 뜰 수 있도록 충분히 과거로)
 
-    void Start()
-    {
-        if (warningText != null)
-        {
-            warningText.text = "";
-        }
-    }
+    private int pedestrianCollisionCount = 0;
+    private float lastPedestrianCollisionTime = -999f;
+    private float pedestrianCollisionCooldown = 3f;
+    private int pedestrianCollisionLimit = 2;
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (Time.time - lastWarningTime < cooldown)
-        {
-            return; // 쿨타임 중
-        }
-
         GameObject other = collision.gameObject;
 
+        // 보행자와 충돌
         if (other.CompareTag("Pedestrian"))
         {
-            ShowWarning("위험! 보행자와 충돌했습니다!");
-
-            // 여기 ↓↓↓
-            if (GameManager.inst == null)
+            if (Time.time - lastPedestrianCollisionTime >= pedestrianCollisionCooldown)
             {
-                Debug.LogError("GameManager 인스턴스가 null입니다!");
+                pedestrianCollisionCount++;
+                lastPedestrianCollisionTime = Time.time;
+
+                Debug.Log($"[충돌] 보행자와 충돌! 현재 충돌 횟수: {pedestrianCollisionCount}/{pedestrianCollisionLimit}");
+                ShowWarning($"보행자와 충돌! ({pedestrianCollisionCount}/{pedestrianCollisionLimit})");
+
+                if (pedestrianCollisionCount >= pedestrianCollisionLimit)
+                {
+                    if (GameManager.inst != null)
+                    {
+                        Debug.Log("보행자 충돌 한도 초과. 라운드 종료!");
+                        GameManager.inst.RoundOver();
+                    }
+                }
             }
             else
             {
-                Debug.Log("GameManager 인스턴스 정상 작동: " + GameManager.inst.name);
-                GameManager.inst.RoundOver();
+                Debug.Log("[충돌] 쿨타임 중이므로 보행자 충돌 카운트 증가 없음");
             }
         }
+
+        // 건물과 충돌
         else if (other.CompareTag("Building"))
         {
             ShowWarning("건물과 충돌했습니다!");
-            if (GameManager.inst != null) GameManager.inst.RoundOver();
+            Debug.Log("[충돌] 건물과 충돌 발생");
+
+            if (GameManager.inst != null)
+            {
+                GameManager.inst.RoundOver();
+            }
         }
+
+        // 차량과 충돌
         else if (other.CompareTag("Car"))
         {
             ShowWarning("다른 차량과 충돌했습니다!");
-            if (GameManager.inst != null) GameManager.inst.RoundOver();
+            Debug.Log("[충돌] 차량과 충돌 발생");
+
+            if (GameManager.inst != null)
+            {
+                GameManager.inst.RoundOver();
+            }
         }
     }
-
 
     void ShowWarning(string message)
     {

--- a/Assets/Scripts/Shop2/PerformanceShopManager.cs
+++ b/Assets/Scripts/Shop2/PerformanceShopManager.cs
@@ -31,7 +31,6 @@ public class PerformanceShopManager : MonoBehaviour
     public PerformanceItemSO[] allItems;
 
     private ShopTab currentTab = ShopTab.Vehicle;
-    private const int totalTurnsPerRound = 5;
     private bool isSubscribed = false;
 
     private void Awake()
@@ -39,8 +38,8 @@ public class PerformanceShopManager : MonoBehaviour
         if (Instance != null && Instance != this) Destroy(gameObject);
         else Instance = this;
 
-        payButton.onClick.RemoveAllListeners(); // 💡 중복 방지
-        payButton.onClick.AddListener(() => TryPayNextStage()); // ✅ 람다로 고정
+        payButton.onClick.RemoveAllListeners(); // 중복 방지
+        payButton.onClick.AddListener(() => TryPayNextStage()); // 람다로 고정
     }
 
     private void OnEnable()
@@ -204,10 +203,13 @@ public class PerformanceShopManager : MonoBehaviour
 
     public void UpdateTurnAndPaymentUI()
     {
-        int remainingTurns = totalTurnsPerRound - (GameDataManager.Instance.data.turn % totalTurnsPerRound);
+        var data = GameDataManager.Instance.data;
+
+        int remainingTurns = data.turn;
+        int maxTurns = data.maxTurnsPerRound;
         string color = remainingTurns <= 1 ? "#FF5555" : "#55FF55";
 
-        turnStatusText.text = $"<color={color}>남은 턴: {remainingTurns} / {totalTurnsPerRound}</color>";
+        turnStatusText.text = $"<color={color}>남은 턴: {remainingTurns} / {maxTurns}</color>";
         paymentAmountText.text = $"집세 : {GameDataManager.Instance.GetRequiredPayment()}원";
     }
 
@@ -218,6 +220,10 @@ public class PerformanceShopManager : MonoBehaviour
         bool success = GameDataManager.Instance.TryPay();
         if (success)
         {
+            GameDataManager.Instance.data.turn = GameDataManager.Instance.data.maxTurnsPerRound;
+
+            GameDataManager.Instance.Save();
+
             UpdateMoneyUI();
             UpdateTurnAndPaymentUI();
         }


### PR DESCRIPTION
 탈출버튼 비활성 오류 수정완료
사람 충돌가능 횟수 증가(2회) 및 충돌 쿨타임 적용(충돌 후 3초간 같은 종류 오브젝트 충돌 카운트x), 라운드 오버시 페이드 씬 추가
라운드 종료 시 남은 납부 턴 줄어드는 로직 적용
라운드 종료 시 납부 턴이 0일경우 해당 게임에서 벌어들인 돈 + 보유하고 있던 금액이 작으면 게임 오버되는 로직 적용
게임데이터 관리 로직 개선 (데이터 사용중인 다른 스크립트에 영향X)

-- 다음주 개선 사항--
충돌로 인해 라운드가 종료되는게 아니라 정상적으로 종료되었을 경우에도 게임오버 로직을 적용시켜야함.
턴이 끝나서 정상적으로 라운드가 종료 되는 부분 살펴보고 다음주까지 적용시켜 놓겠습니다@@ 

--다음주~다다음주 추가 사항--
일회성 아이템 간단하게라도 몇개 추가 (아이디어 환영)
현재 구상중인건 차량 긴급수리 키트(차량 고장시 1회 차량 내구도 최대로 채워줌), 보험 가입(라운드 종료시 합의금 50% 할인)
충돌 이벤트 수정(라운드 오버 -> 사람 충돌시 충돌 횟수 * n원 만큼 라운드 종료시 보유금액에서 합의금으로 차감, 차량,건물과 너무 많은 충돌을 일으킬 시 차량 고장으로 징수화면으로 쫒겨남 + 수리금 차감)